### PR TITLE
Compress DNS responses and truncate them if using UDP transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 ENTRYPOINT ["/bin/resolvable"]
 
 COPY ./config /config


### PR DESCRIPTION
Using resolvable made docker stop working:
```
$ docker run -it gliderlabs/alpine  /bin/sh
Unable to find image 'gliderlabs/alpine:latest' locally
Pulling repository docker.io/gliderlabs/alpine
Error while pulling image: Get https://index.docker.io/v1/repositories/gliderlabs/alpine/images: dial tcp: lookup index.docker.io on 172.17.0.1:53: cannot unmarshal DNS message
```

Solution shamelessly stolen from: https://github.com/mesosphere/mesos-dns/pull/173

Updating to `alpine:3.2` was required because `github.com/miekg/dns` would not work with `go-1.3.3-r1` available in `alpine:3.1`