### PR TITLE
Use gliderlabs/alpine:3.3 as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM alpine:3.1
+FROM gliderlabs/alpine:3.3
 ENTRYPOINT ["/bin/resolvable"]
 
+RUN apk add --no-cache -t build-deps go git mercurial
 COPY ./config /config
 COPY . /src
 RUN cd /src && ./build.sh "$(cat VERSION)"

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
-apk add --update -t build-deps go git mercurial
 mkdir -p /go/src/github.com/gliderlabs
 cp -r /src /go/src/github.com/gliderlabs/resolvable
 cd /go/src/github.com/gliderlabs/resolvable


### PR DESCRIPTION
Moving `apk-add` from build script to the Dockerfile makes the build faster, as docker build can cahce the package installation.