### PR TITLE
Added by Schinti95: IP Address lookup when using docker networks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple DNS server to resolve names of local Docker containers.
 
+`Added by Schinti95:` IP Address lookup when using docker networks.
+
 `resolvable` is intended to run in a Docker container:
 
 	docker run -d \

--- a/main.go
+++ b/main.go
@@ -101,6 +101,12 @@ func registerContainers(docker *dockerapi.Client, events chan *dockerapi.APIEven
 				}
 				continue
 			}
+			for key, value := range container.NetworkSettings.Networks {
+                fmt.Println("Network-Name:", key)
+					if value.IPAddress != "" {
+						return net.ParseIP(value.IPAddress), nil
+					}
+            }
 
 			return nil, fmt.Errorf("unknown network mode", container.HostConfig.NetworkMode)
 		}
@@ -229,7 +235,7 @@ func run() error {
 	}
 	defer dnsResolver.Close()
 
-	localDomain := "docker"
+	localDomain := "internal"
 	dnsResolver.AddUpstream(localDomain, nil, 0, localDomain)
 
 	resolvConfig, err := dns.ClientConfigFromFile("/etc/resolv.conf")

--- a/main.go
+++ b/main.go
@@ -102,8 +102,8 @@ func registerContainers(docker *dockerapi.Client, events chan *dockerapi.APIEven
 				continue
 			}
 			for key, value := range container.NetworkSettings.Networks {
-                fmt.Println("Network-Name:", key)
 					if value.IPAddress != "" {
+		                log.Println("Found Container with IP: ", value.IPAddress, "from Network: ", key)
 						return net.ParseIP(value.IPAddress), nil
 					}
             }


### PR DESCRIPTION
As of Docker 1.10, the docker daemon implements an embedded DNS server which provides built-in service discovery for any container created with a valid name or net-alias or aliased by link.

I am using:
- Docker version 1.11.2, build b9f10c9
- docker-compose version 1.7.1, build 0a9ab35, 

with a Version 2 yaml file. Composer adds a [dir]_default network by default.

I get errors when using gliderlabs/resolvable:master:

``` bash
resolvable_1  | 2016/06/19 04:52:56 Starting resolvable 0.2 ...
resolvable_1  | 2016/06/19 04:52:56 got local address: 172.18.0.2
resolvable_1  | 2016/06/19 04:52:56 updating resolv.conf: /tmp/resolv.conf
resolvable_1  | 2016/06/19 04:52:56 error adding container d60615318259: unknown network mode%!(EXTRA string=drupal7_default)
resolvable_1  | 2016/06/19 04:52:56 error adding container d60615318259: unknown network mode%!(EXTRA string=drupal7_default)
resolvable_1  | 2016/06/19 04:52:56 error adding container 9f4c649a0fcf: unknown network mode%!(EXTRA string=drupal7_default)
```

After building Schinti95's repo, the errors are gone:

``` bash
resolvable_1  | 2016/06/19 05:05:21 Starting resolvable 0.2 ...
resolvable_1  | 2016/06/19 05:05:21 got local address: 172.18.0.2
resolvable_1  | 2016/06/19 05:05:21 updating resolv.conf: /tmp/resolv.conf
resolvable_1  | 2016/06/19 05:05:21 Found Container with IP:  172.18.0.2 from Network:  drupal7_default
resolvable_1  | 2016/06/19 05:05:21 Found Container with IP:  172.18.0.3 from Network:  drupal7_default
```

Looks good to me.
