### PR TITLE
reflect upstream changes to coreos/go-systemd

### DIFF
--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -93,12 +93,12 @@ func (r *SystemdConfig) StoreAddress(address string) error {
 		}
 	}
 
-	daemon.SdNotify("READY=1")
+	daemon.SdNotify(false, "READY=1")
 	return nil
 }
 
 func (r *SystemdConfig) Clean() {
-	daemon.SdNotify("STOPPING=1")
+	daemon.SdNotify(false, "STOPPING=1")
 
 	for service, filenames := range r.written {
 		log.Printf("systemd: %s: removing configs...", service)


### PR DESCRIPTION
call signature changed upstream. believe this PR preserves old behavior.

cf. https://github.com/coreos/go-systemd/commit/0c088eaedf4396216a47ca971d4630f1697186bf#diff-9d288707062cfed66121eaf8aa1aa906